### PR TITLE
Fix styling issue on stackoverflow dark mode

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -121,7 +121,7 @@ const createAnswerElement = isError => {
   textElement.className = "s-prose js-post-body";
   textElement.id = isError ? "chatGPTErrorText" : "chatGPTAnswerText";
 
-  stylizeAnswerElement(answerElement);
+  // stylizeAnswerElement(answerElement);
   stylizeBodyElement(bodyElement);
   stylizeLHSElement(lhsElement);
   stylizeRHSElement(rhsElement, isError);
@@ -143,7 +143,7 @@ const populateAnswerText = chatGPTOutput => {
     if (index % 2) { // Code block
       const preElement = document.createElement("pre");
       preElement.className = "default s-code-block";
-      preElement.style.backgroundColor = "#e3e5e6";
+      // preElement.style.backgroundColor = "#e3e5e6";
 
       const codeElement = document.createElement("code");
       const highlightedCode = hljs.highlightAuto(textBlock.trim());


### PR DESCRIPTION
Closes #1.

How it looks on dark mode with this PR:
<img width="752" alt="CleanShot-2023-02-28T13-07-57@2x" src="https://user-images.githubusercontent.com/45612704/221759550-6df6b113-b0c7-433a-8d70-a779f8b4ed8b.png">
